### PR TITLE
Fixup broken CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.python }}-${{ github.ref }}
       cancel-in-progress: true
@@ -22,19 +22,19 @@ jobs:
       fail-fast: false
       matrix:
         python: [
-          "3.7",
-          "3.8",
           "3.9",
           "3.10",
-          "3.11.0-rc.1",
+          "3.11",
+          "3.12",
+          "3.13"
         ]
     name: Python ${{ matrix.python }}
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Configure Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
@@ -42,15 +42,22 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt -y update
-          sudo apt -y install gcc libsystemd-dev
-          python -m pip install pytest sphinx
-
+          sudo apt -y install gcc libsystemd-dev python3-setuptools
+      - name: Create virtualenv
+        run: |
+          python3 -m venv ~/${{ matrix.python }}
+      - name: Install python dependencies
+        run: |
+          source ~/${{ matrix.python }}/bin/activate
+          python3 -m pip install pytest sphinx setuptools
       - name: Build (Python ${{ matrix.python }})
         run: |
           set -x
+          source ~/${{ matrix.python }}/bin/activate
           make -j
           make doc SPHINXOPTS="-W -v"
 
       - name: Test (Python ${{ matrix.python }})
         run: |
+          source ~/${{ matrix.python }}/bin/activate
           make check

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.container }}-${{ github.ref }}
       cancel-in-progress: true
@@ -24,16 +24,16 @@ jobs:
         container: [
             "archlinux:latest",
             "debian:testing",
-            "quay.io/centos/centos:stream8",
+            "quay.io/centos/centos:stream9",
             "quay.io/fedora/fedora:rawhide",
-            "ubuntu:focal",
+            "ubuntu:noble",
         ]
     container:
       image: ${{ matrix.container }}
     name: ${{ matrix.container }}
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         shell: bash
@@ -52,14 +52,20 @@ jobs:
           case "$DIST_ID" in
           arch)
               pacman --noconfirm -Sy "${DEPS_COMMON[@]}" systemd-libs
+              python3 -m venv ~/venv
+              source ~/venv/bin/activate
               python3 -m ensurepip
               ;;
           centos|fedora)
-              dnf -y install "${DEPS_COMMON[@]}" systemd-devel python3-devel python3-pip
+              dnf -y install "${DEPS_COMMON[@]}" systemd-devel python3-devel python3-pip python3-setuptools
+              python3 -m venv ~/venv
+              source ~/venv/bin/activate
               ;;
           ubuntu|debian)
               apt -y update
-              DEBIAN_FRONTEND=noninteractive apt -y install "${DEPS_COMMON[@]}" libsystemd-dev python3-dev python3-pip
+              DEBIAN_FRONTEND=noninteractive apt -y install "${DEPS_COMMON[@]}" libsystemd-dev python3-dev python3-pip python3-setuptools python3-venv
+              python3 -m venv ~/venv
+              source ~/venv/bin/activate
               ;;
           *)
               echo >&2 "Invalid distribution ID: $DISTRO_ID"
@@ -71,6 +77,7 @@ jobs:
       - name: Build & install
         shell: bash
         run: |
+          source ~/venv/bin/activate
           set -x
           python3 -m pip install -I -v .
           # Avoid importing the systemd module from the git repository

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON = python
+PYTHON = python3
 SED = sed
 ETAGS = etags
 INCLUDE_DIR := $(shell pkg-config --variable=includedir libsystemd)


### PR DESCRIPTION
Around the beginning of 2025, the `ubuntu-latest` runner image which [this project uses][1], [was changed from Ubuntu 22.04 to 24.04][2].

As a result, the python version which is used by this repo's GitHub actions changed from [3.10.12][3] to [3.12.3][4].

With this change to Python 3.12, [PEP 668][5] was introduced. This new Python behavior is causing errors in the CI and `pip` is exiting non-zero

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.13/README.venv for more information.
```

This commit changes the CI to use virtualenvs to address this externally-managed-environment problem.

This also fixes up or updates CI by

* Changing the build image from Ubuntu 20.04 to 24.04
* Updating the list of Python versions tested to just the current supported Python versions
* Updating the versions of the `checkout` and `setup-python` actions
* Anchoring the install image to Ubuntu 24.04 (instead of `latest`) to prevent this type of thing in the future
* Updating container OSes for install
   * CentOS Stream 8 to CentOS Stream 9 as Stream 8 is end of lifed
   * Ubuntu focatl to noble

[1]: https://github.com/systemd/python-systemd/blob/903142423452c4dd18110b7f8a953dabb2031e49/.github/workflows/install.yml#L17
[2]: https://github.com/actions/runner-images/issues/10636
[3]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#installed-software
[4]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#language-and-runtime
[5]: https://peps.python.org/pep-0668/